### PR TITLE
add is.ErrMsg(err, "...")

### DIFF
--- a/is.go
+++ b/is.go
@@ -188,6 +188,16 @@ func (is *Is) Err(e error) {
 	}
 }
 
+// ErrMsg checks the provided error object to determine if error message matches the expected string
+func (is *Is) ErrMsg(e error, expectedMsg string) {
+	is.TB.Helper()
+	if isNil(e) {
+		fail(is, "expected error %#v", expectedMsg)
+	} else {
+		is.Equal(e.Error(), expectedMsg)
+	}
+}
+
 // NotErr checks the provided error object to determine if an error is not
 // present.
 func (is *Is) NotErr(e error) {

--- a/is_test.go
+++ b/is_test.go
@@ -141,6 +141,7 @@ func TestIs(t *testing.T) {
 	is.Nil(nil)
 	is.NotNil(&testStruct{v: 1})
 	is.Err(errors.New("error"))
+	is.ErrMsg(errors.New("another error"), "another error")
 	is.NotErr(nil)
 	is.True(true)
 	is.False(false)


### PR DESCRIPTION
Usually the error message (and probably error code) that our api or library returns is very important (we don't want to give Internal Server Error instead of Unauthorized, for example)

Since error interface has no extra information than message, we can only validate the massage and type (at least in a generic Go library like "is" or "testify").
But most of the time, validating message is enough.

Similar to [`assert.EqualError`](https://github.com/stretchr/testify/blob/master/assert/assertions.go#L1194)

Checking the error type is trickier because sometimes the type (struct) is not exported by library (like grpc errors), so we will have to pass the type string and check against `fmt.Sprintf("%T", err)`, maybe can add a new function for that, like `is.ErrEqual` or `is.ErrMsgType` if you agree